### PR TITLE
Handle warps better

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ImageProjectiveGeometry = "b9d14576-938f-5430-9d4c-b7d7de1409d6"

--- a/src/DiffImages.jl
+++ b/src/DiffImages.jl
@@ -11,12 +11,14 @@ using Flux,
       CoordinateTransformations,
       ImageProjectiveGeometry
 
-using Flux:@functor, unsqueeze
-using Zygote:@adjoint
-using ChainRules:NoTangent
+using Flux: @functor, unsqueeze
+using Zygote: @adjoint
+using ChainRules: NoTangent
+using ChainRulesCore
 
 export colorify, channelify
 include("colors/conversions.jl")
 include("geometry/warp.jl")
+include("geometry/adjoints.jl")
 
 end # module

--- a/src/geometry/adjoints.jl
+++ b/src/geometry/adjoints.jl
@@ -59,3 +59,9 @@ end
 Zygote.@adjoint function SVector{N,T}(x...) where {T,N}
   SVector{N,T}(x...), Δ -> (Δ...,)
 end
+
+# Zygote.@nograd custom_autorange
+
+Zygote.@adjoint function CartesianIndices(t::Tuple)
+  CartesianIndices(t), Δ -> (Δ,)
+end

--- a/src/geometry/adjoints.jl
+++ b/src/geometry/adjoints.jl
@@ -51,7 +51,12 @@ end
 function ChainRulesCore.rrule(itp::AbstractExtrapolation, x...)
   y = itp(x...)
   function pullback(Δy)
-    (Δy, Interpolations.gradient(itp, x...)...)
+    tmp = if checkbounds(Bool, itp, x...)
+      Interpolations.gradient(itp, x...)
+    else
+      ntuple(_ -> zero.(eltype(itp)), length(x))
+    end
+    (Δy, tmp...)
   end
   y, pullback
 end

--- a/src/geometry/warp.jl
+++ b/src/geometry/warp.jl
@@ -12,7 +12,7 @@ end
 # Defining required methods for ImageTransformations.warp to work
 function (h::homography{T})(x::SVector{3,K}) where {T,K}
     y = h.H*x
-    return (y./y[end])[1:2]
+    return y[1:2] # (y./y[end])[1:2]
 end
 
 function (h::homography{T})(x::SVector{2,K}) where {T,K}


### PR DESCRIPTION
@SomTambe some notes:

1. The adjoints were not imported at all - not sure how you were testing the warps
2. Please use better spacing - otherwise its kind of hard to read
3. you'll need to define and no grad custom_autorange. It should ideally be gone
4. should we have a separate pass for the normalising of the homography matrix and define an adjoint over it?
5. This currently needs a dep on `ImageTransformations#master` and probably soon-ish on `Interpolations#master` once the `FilledExtrapolation` issue is sorted - so maybe we need a Manifest.toml in the repo.
6. Why not use the homography from ImageProjectiveGeometry directly?

otherwise, after a lot of annoying imports and redefinitions of the `warp_me2` function (it should really just use the in-place version)


## Define some stuff from your gist + an out-of-place warp
```julia
function custom_autorange(R::CartesianIndices, tform)
    tform = _round(tform)
    mn = mx = tform(SVector(first(R).I))
    for I in (first(R), last(R))
        x = tform(SVector(I.I))
        # we map min and max to prevent type-inference issues
        # (because min(::SVector,::SVector) -> Vector)
        mn = map(min, x, mn)
        mx = map(max, x, mx)
    end
    @show mn mx
    _autorange(Tuple(mn), Tuple(mx))
end

custom_autorange(A::AbstractArray, tform) = custom_autorange(CartesianIndices(A), tform)

_autorange(mn,mx) = map((a,b)->floor(Int,a):ceil(Int,b), mn, mx)

Zygote.@nograd custom_autorange

function warp_me2(img::AbstractArray{T}, tform) where T
  img = box_extrapolation(img, fillvalue = Interpolations.Flat())
  e = eltype(img)
  inds = custom_autorange(img, inv(tform))
  # out = similar(img, inds)
  # warp!(out, img, try_static(tform, img))
  map(x -> ImageTransformations._getindex(img, tform(SVector(x.I))), CartesianIndices(inds))
end
```

## Run in REPL
```Julia
julia> using DiffImages, Images, Interpolations, Zygote, ImageProjectiveGeometry, ImageTransformations, StaticArrays, ChainRules, ChainRulesCore

julia> src_img = rand(RGB{Float64}, 512, 512);

julia> tgt_img = rand(RGB{Float64}, 512, 512);

julia> srcs=[[220,24,1] [218,1018,1] [524,928,1] [526,124,1.]]

3×4 Matrix{Float64}:
 220.0   218.0  524.0  526.0
  24.0  1018.0  928.0  124.0
   1.0     1.0    1.0    1.0

julia> tgts=[[482,50,1] [478,1002,1] [770,928,1] [772,126,1.]]
3×4 Matrix{Float64}:
 482.0   478.0  770.0  772.0
  50.0  1002.0  928.0  126.0
   1.0     1.0    1.0    1.0

julia> h=homography2d(srcs,tgts)
3×3 Matrix{Float64}:
 -0.503896    0.00340999  -175.764
  0.0468877  -0.565009     -26.4791
  7.7077e-5   4.40527e-6    -0.611543

julia> h=DiffImages.homography{Float64}(h)
DiffImages.homography{Float64}([-0.5038963002547231 0.0034099870114483416 -175.76436644639742; 0.046887687993352134 -0.5650088055245436 -26.4791166249276; 7.70770117376499e-5 4.4052650320161396e-6 -0.6115434009226398])

julia> Zygote.gradient(src2, h) do img, tform
                c = sum(warp_me2(img, tform))
                c.r + c.g + c.b
              end[2].H
mn = [302.5189163384686, -126.55063663855283]
mx = [544.9331176001162, 116.82751548448107]
3×3 SMatrix{3, 3, RGB{Float64}, 9} with indices SOneTo(3)×SOneTo(3):
 RGB{Float64}(0.0,0.0,0.0)                …  RGB{Float64}(0.0,0.0,0.0)
 RGB{Float64}(-13077.0,10938.6,-19654.3)     RGB{Float64}(-32.6054,25.9136,-49.5508)
 RGB{Float64}(0.0,0.0,0.0)                   RGB{Float64}(0.0,0.0,0.0)
```