### PR TITLE
Fixing errored tests in adjoints.jl

### DIFF
--- a/docs/src/tutorials/homog/warp.md
+++ b/docs/src/tutorials/homog/warp.md
@@ -11,7 +11,7 @@ In this example, we will train a homography matrix using DiffImages.jl.
 ### Importing the libraries
 ```@setup homo
 using Pkg
-Pkg.add(["ImageTransformations", "ImageCore", "Zygote", "FileIO", "ImageMagick"])
+Pkg.add(["ImageTransformations", "ImageCore", "Zygote", "FileIO"])
 ```
 ```@repl homo
 using DiffImages, ImageCore, ImageTransformations, FileIO, Zygote

--- a/docs/src/tutorials/rotate/rotate.md
+++ b/docs/src/tutorials/rotate/rotate.md
@@ -11,7 +11,7 @@ In this tutorial, I will train a Rotation matrix.
 Let us first import the required libraries.
 ```@setup rot
 using Pkg
-Pkg.add(["ImageTransformations", "ImageCore", "Zygote", "CoordinateTransformations", "FileIO", "ImageMagick"])
+Pkg.add(["ImageTransformations", "ImageCore", "Zygote", "CoordinateTransformations", "FileIO"])
 ```
 ```@repl rot
 using DiffImages, ImageTransformations, CoordinateTransformations, ImageCore, FileIO, StaticArrays

--- a/test/geometry/adjoints.jl
+++ b/test/geometry/adjoints.jl
@@ -106,11 +106,19 @@ end
         itp = extrapolate(interpolate(rand(t, 3, 3), BSpline(Linear())), zero(t))
         for ind in ((2.5, 2.5), (5, 5))
             if t <: Colorant
+<<<<<<< HEAD
                 zy = Zygote.gradient((x, y) -> _sep(ImageTransformations._getindex(x, y)), itp, ind)
                 @test all(zy[2] .≈ Tuple(_sep.(Interpolations.gradient(itp, ind...))))
             else
                 zy = Zygote.gradient((x, y) -> ImageTransformations._getindex(x, y), itp, ind)
                 @test all(zy[2] .≈ Tuple(Interpolations.gradient(itp, ind...)))
+=======
+                zy = Zygote.gradient((x,y)->_sep(ImageTransformations._getindex(x,y)), itp, ind)
+                @test zy[2] ≈ fieldsum.(Interpolations.gradient(itp, ind...))
+            else
+                zy = Zygote.gradient((x,y)->ImageTransformations._getindex(x,y), itp, ind)
+                @test zy[2] ≈ Interpolations.gradient(itp, ind...)
+>>>>>>> parent of c4b5ef5 (Fixing errored tests in adjoints.jl)
             end
         end
     end

--- a/test/geometry/adjoints.jl
+++ b/test/geometry/adjoints.jl
@@ -1,42 +1,42 @@
 m = rand(3, 3)
 axs = (1:3, 1:3)
-ty = Interpolations.BSplineInterpolation{Float64, ndims(m), typeof(m), BSpline{Linear{Throw{OnGrid}}}, typeof(axs)}
-etty = Interpolations.Extrapolation{Float64, 2, Interpolations.BSplineInterpolation{Float64, 2, Matrix{Float64}, BSpline{Linear{Throw{OnGrid}}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}}, BSpline{Linear{Throw{OnGrid}}}, Flat{Nothing}}
-fieldsum(x) = mapreduce(y->getfield(x, y), +, ntuple(identity, nfields(x)))
+ty = Interpolations.BSplineInterpolation{Float64,ndims(m),typeof(m),BSpline{Linear{Throw{OnGrid}}},typeof(axs)}
+etty = Interpolations.Extrapolation{Float64,2,Interpolations.BSplineInterpolation{Float64,2,Matrix{Float64},BSpline{Linear{Throw{OnGrid}}},Tuple{UnitRange{Int64},UnitRange{Int64}}},BSpline{Linear{Throw{OnGrid}}},Flat{Nothing}}
+fieldsum(x) = mapreduce(y -> getfield(x, y), +, ntuple(identity, nfields(x)))
 
 @testset "Interpolations.BSplineInterpolation constructor gradient" begin
-    zg = Zygote.gradient((x,y,z)->sum(ty(x,y,z)), m, axs, BSpline(Linear()))
-    fd = grad(central_fdm(5,1), 
-              x->sum(ty(x, axs, BSpline(Linear()))), 
-              m)
+    zg = Zygote.gradient((x, y, z) -> sum(ty(x, y, z)), m, axs, BSpline(Linear()))
+    fd = grad(central_fdm(5, 1),
+        x -> sum(ty(x, axs, BSpline(Linear()))),
+        m)
     @test isapprox(zg[1], fd[1])
     @test zg[2:3] == (nothing, nothing)
 end
 
 @testset "Interpolations.BSplineInterpolation functor gradient" begin
-    zg = Zygote.gradient((x,y,z,w)->sum(Interpolations.BSplineInterpolation(x,y,z,w)), Float64, m, BSpline(Linear()), axs)
-    fd = grad(central_fdm(5,1), 
-              x->sum(Interpolations.BSplineInterpolation(Float64, x, BSpline(Linear()), axs)), 
-              m)
+    zg = Zygote.gradient((x, y, z, w) -> sum(Interpolations.BSplineInterpolation(x, y, z, w)), Float64, m, BSpline(Linear()), axs)
+    fd = grad(central_fdm(5, 1),
+        x -> sum(Interpolations.BSplineInterpolation(Float64, x, BSpline(Linear()), axs)),
+        m)
     @test isapprox(zg[2], fd[1])
     @test findall(==(nothing), zg) == [1, 3, 4]
 end
 
 @testset "Interpolations.Extrapolation constructor gradient" begin
     itp = ty(m, axs, BSpline(Linear()))
-    zg = Zygote.gradient((x,y)->sum(etty(x,y)), itp, Flat())
-    fd = grad(central_fdm(5,1), 
-              x->sum(etty(itp, Flat())), 
-              m)
+    zg = Zygote.gradient((x, y) -> sum(etty(x, y)), itp, Flat())
+    fd = grad(central_fdm(5, 1),
+        x -> sum(etty(itp, Flat())),
+        m)
     @test isapprox(zg[1], fd[1])
     @test findall(==(nothing), zg) == [2]
 end
 
 @testset "Interpolations.copy_with_padding function gradient" begin
-    zg = Zygote.gradient((x,y,z)->sum(Interpolations.copy_with_padding(x,y,z)), Float64, m, BSpline(Linear()))
-    fd = grad(central_fdm(5,1), 
-              x->sum(Interpolations.copy_with_padding(Float64, x, BSpline(Linear()))), 
-              m)
+    zg = Zygote.gradient((x, y, z) -> sum(Interpolations.copy_with_padding(x, y, z)), Float64, m, BSpline(Linear()))
+    fd = grad(central_fdm(5, 1),
+        x -> sum(Interpolations.copy_with_padding(Float64, x, BSpline(Linear()))),
+        m)
     @test isapprox(zg[2], fd[1])
     @test findall(==(nothing), zg) == [1, 3]
 end
@@ -44,10 +44,10 @@ end
 @testset "Interpolations.FilledExtrapolation constructor gradient" begin
     @test_broken begin
         itp = ty(m, axs, BSpline(Linear()))
-        zg = Zygote.gradient((x,y)->sum(Interpolations.FilledExtrapolation(x,y)), itp, 0.0)
-        fd = grad(central_fdm(5,1), 
-                x->sum(Interpolations.FilledExtrapolation(x, 0.0)), 
-                itp)
+        zg = Zygote.gradient((x, y) -> sum(Interpolations.FilledExtrapolation(x, y)), itp, 0.0)
+        fd = grad(central_fdm(5, 1),
+            x -> sum(Interpolations.FilledExtrapolation(x, 0.0)),
+            itp)
         @test_broken isapprox(zg[1], fd[1])
         @test_broken findall(==(nothing), zg) == [2]
     end # TODO: Remove the @test_broken after tests work.
@@ -57,17 +57,17 @@ end
     for t in (Float32, Float64, RGB{Float32}, RGB{Float64})
         inp = rand(t, 2)
         inp_mat = rand(t, 3, 3)
-        _abs(c)  = mapreducec(v->abs(float(v)), +, 0, c)
-        @test Zygote.gradient(x->_abs(sum(SVector{2, t}(x))), inp)[1] == ones(t, 2)
-        @test Zygote.gradient(x->_abs(sum(SMatrix{3, 3, t, 9}(x))), inp_mat)[1] == ones(t, 3, 3)
+        _abs(c) = mapreducec(v -> abs(float(v)), +, 0, c)
+        @test Zygote.gradient(x -> _abs(sum(SVector{2,t}(x))), inp)[1] == ones(t, 2)
+        @test Zygote.gradient(x -> _abs(sum(SMatrix{3,3,t,9}(x))), inp_mat)[1] == ones(t, 3, 3)
     end
 end
 
 @testset "DiffImages.Homography method gradient" begin
     h = DiffImages.Homography{Float64}()
-    v = rand(SVector{2, Float64})
-    zy = Zygote.gradient((x,y)->sum(y(x)), v, h)
-    fd = grad(central_fdm(5,1), (x,y)->sum(y(x)), v, h)
+    v = rand(SVector{2,Float64})
+    zy = Zygote.gradient((x, y) -> sum(y(x)), v, h)
+    fd = grad(central_fdm(5, 1), (x, y) -> sum(y(x)), v, h)
     @test (zy[1] .≈ fd[1]) == Bool[1, 1]
     @test zy[2].H ≈ fd[2].H
     @test typeof(zy[2].H) == typeof(fd[2].H)
@@ -75,13 +75,13 @@ end
 
 @testset "CoordinateTransformations.LinearMap gradient" begin
     m = CoordinateTransformations.LinearMap(rand(3, 3))
-    sm = CoordinateTransformations.LinearMap(rand(SMatrix{3, 3, Float64}))
+    sm = CoordinateTransformations.LinearMap(rand(SMatrix{3,3,Float64}))
     v = rand(3)
-    sv = rand(SVector{3, Float64})
-    zy = Zygote.gradient((x, y)->sum(x(y)), m, v)
-    fd = grad(central_fdm(5,1), (x, y)->sum(x(y)), m, v)
-    zy_s = Zygote.gradient((x, y)->sum(x(y)), sm, sv)
-    fd_s = grad(central_fdm(5,1), (x, y)->sum(x(y)), sm, sv)
+    sv = rand(SVector{3,Float64})
+    zy = Zygote.gradient((x, y) -> sum(x(y)), m, v)
+    fd = grad(central_fdm(5, 1), (x, y) -> sum(x(y)), m, v)
+    zy_s = Zygote.gradient((x, y) -> sum(x(y)), sm, sv)
+    fd_s = grad(central_fdm(5, 1), (x, y) -> sum(x(y)), sm, sv)
 
     @test zy[1].linear ≈ fd[1].linear
     @test zy[2] ≈ fd[2]
@@ -92,25 +92,26 @@ end
 end
 
 @testset "Rotations.RotMatrix{N, T, L} gradient" begin
-    rm = RotMatrix(π/4)
+    rm = RotMatrix(π / 4)
     v = rand(2)
-    zy = Zygote.gradient((x, y)->sum(LinearMap(x)(y)), rm, v)
-    fd = grad(central_fdm(5,1), (x, y)->sum(LinearMap(x)(y)), rm, v)
+    zy = Zygote.gradient((x, y) -> sum(LinearMap(x)(y)), rm, v)
+    fd = grad(central_fdm(5, 1), (x, y) -> sum(LinearMap(x)(y)), rm, v)
     @test zy[1] ≈ fd[1]
     @test zy[2] ≈ fd[2]
 end
 
 @testset "ImageTransformations._getindex gradient" begin
     _sep(x) = x.r + x.g + x.b
+    Base.isapprox(x::Tuple, y::Tuple; kws...) = isapprox(collect(x), collect(y); kws...)
     for t in (Float32, Float64, RGB{Float32}, RGB{Float64})
         itp = extrapolate(interpolate(rand(t, 3, 3), BSpline(Linear())), zero(t))
         for ind in ((2.5, 2.5), (5, 5))
             if t <: Colorant
-                zy = Zygote.gradient((x,y)->_sep(ImageTransformations._getindex(x,y)), itp, ind)
-                @test zy[2] == Tuple(_sep.(Interpolations.gradient(itp, ind...)))
+                zy = Zygote.gradient((x, y) -> _sep(ImageTransformations._getindex(x, y)), itp, ind)
+                @test isapprox(zy[2], Tuple(_sep.(Interpolations.gradient(itp, ind...))))
             else
-                zy = Zygote.gradient((x,y)->ImageTransformations._getindex(x,y), itp, ind)
-                @test zy[2] == Tuple(Interpolations.gradient(itp, ind...))
+                zy = Zygote.gradient((x, y) -> ImageTransformations._getindex(x, y), itp, ind)
+                @test isapprox(zy[2], Tuple(Interpolations.gradient(itp, ind...)))
             end
         end
     end

--- a/test/geometry/adjoints.jl
+++ b/test/geometry/adjoints.jl
@@ -107,10 +107,10 @@ end
         for ind in ((2.5, 2.5), (5, 5))
             if t <: Colorant
                 zy = Zygote.gradient((x,y)->_sep(ImageTransformations._getindex(x,y)), itp, ind)
-                @test zy[2] ≈ fieldsum.(Interpolations.gradient(itp, ind...))
+                @test zy[2] == Tuple(_sep.(Interpolations.gradient(itp, ind...)))
             else
                 zy = Zygote.gradient((x,y)->ImageTransformations._getindex(x,y), itp, ind)
-                @test zy[2] ≈ Interpolations.gradient(itp, ind...)
+                @test zy[2] == Tuple(Interpolations.gradient(itp, ind...))
             end
         end
     end

--- a/test/geometry/adjoints.jl
+++ b/test/geometry/adjoints.jl
@@ -102,16 +102,15 @@ end
 
 @testset "ImageTransformations._getindex gradient" begin
     _sep(x) = x.r + x.g + x.b
-    Base.isapprox(x::Tuple, y::Tuple; kws...) = isapprox(collect(x), collect(y); kws...)
     for t in (Float32, Float64, RGB{Float32}, RGB{Float64})
         itp = extrapolate(interpolate(rand(t, 3, 3), BSpline(Linear())), zero(t))
         for ind in ((2.5, 2.5), (5, 5))
             if t <: Colorant
                 zy = Zygote.gradient((x, y) -> _sep(ImageTransformations._getindex(x, y)), itp, ind)
-                @test isapprox(zy[2], Tuple(_sep.(Interpolations.gradient(itp, ind...))))
+                @test all(zy[2] .≈ Tuple(_sep.(Interpolations.gradient(itp, ind...))))
             else
                 zy = Zygote.gradient((x, y) -> ImageTransformations._getindex(x, y), itp, ind)
-                @test isapprox(zy[2], Tuple(Interpolations.gradient(itp, ind...)))
+                @test all(zy[2] .≈ Tuple(Interpolations.gradient(itp, ind...)))
             end
         end
     end


### PR DESCRIPTION
This PR resolves Issue #22.
This PR has the sole motive to fix the 8 errored tests ( "@testset "ImageTransformations._getindex gradient" ) in the adjoints.jl file.
Type incompatibility was the issue for the tests failing which is resolved and now all of them are passing successfully.
![image](https://user-images.githubusercontent.com/76823502/162535797-9dc6bed5-76b3-4329-89e8-d860cd50aa2a.png)

Hopefully the PR helps.